### PR TITLE
Add custom ref support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,6 @@ class DebouncedInput extends React.Component<*, *> {
         } = this.props;
         delete props.onBeforeChange;
 
-        // $FlowFixMe
         props[(refProp: string)] = el => {
             this.input = refCallback(el);
         };
@@ -163,9 +162,6 @@ class DebouncedInput extends React.Component<*, *> {
         return (
             <InputComponent
                 {...props}
-                ref={el => {
-                    this.input = el;
-                }}
                 value={value}
                 onChange={this.onChange}
                 onBlur={this.onBlur}


### PR DESCRIPTION
When using this component in combination with `react-textarea-autosize`, which does not support the classic `ref` callback, we need a way to tell `DebouncedInput` how to get a ref to the real input.

The new props `refProp` allows to put the ref callback in `inputRef` for example.

```jsx
            <DebouncedInput
                component={Textarea}
                value={value}
                onChange={onChange}
                refProp="inputRef"
                ref={debouncedInput => {
                    this.input = debouncedInput;
                }}
```

The `refCallback` can serve if you are using a wrapped components and need to do things like:

```jsx
ref => this.input = ref.getWrappedInstance()
```